### PR TITLE
Add truncation option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,6 @@ Description: This package contains functions to process (mainly spatial) data an
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
 URL: https://ninanor.github.io/ecTools/
 Imports: 
     bookdown,
@@ -34,3 +33,4 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 VignetteBuilder: quarto
+Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,5 +30,7 @@ Suggests:
     rmarkdown,
     tmap,
     textclean,
-    quarto
+    quarto,
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3
 VignetteBuilder: quarto

--- a/R/ec_normalise.R
+++ b/R/ec_normalise.R
@@ -28,6 +28,10 @@
 #'   `fun = "exponential convex"`. Defaults to 0.5.
 #' @param concave_exponent Numeric. Exponent used when
 #'   `fun = "exponential concave"`. Defaults to 2.
+#' @param truncation Logical. If `TRUE` (the default), normalised values are
+#'   clamped to the interval `[0, 1]`. If `FALSE`, values outside the reference
+#'   range are linearly extrapolated and may fall below 0 or above 1. Disabling
+#'   truncation is only supported when `fun = "linear"`.
 #'
 #' @details
 #' All reference parameters (`x0`, `x60`, `x100`, `x60h`, and `x0h`) may be
@@ -36,7 +40,11 @@
 #' `x0` and `x100` must be consistent for all observations; that is, all
 #' observations must either have `x0 < x100` or all must have `x0 > x100`.
 #'
-#' Values outside the reference range are truncated to the interval `[0, 1]`.
+#' By default, values outside the reference range are truncated to the interval
+#' `[0, 1]`. Set `truncation = FALSE` to instead extrapolate the linear mapping
+#' beyond the reference range, returning values below 0 or above 1. This is only
+#' available when `fun = "linear"`, because the non-linear transformations would
+#' otherwise produce `NaN` for negative extrapolated values.
 #'
 #' Two-sided normalisation with defined `x60` values is currently not supported.
 #' Exponential transformations are currently not supported when `x60` is used.
@@ -80,6 +88,13 @@
 #'   x0 = rep(0, length(x)),
 #'   x100 = seq(5, 10, length.out = length(x))
 #' )
+#'
+#' ec_normalise(
+#'   variable = c(-2, 0, 5, 10, 12),
+#'   x0 = 0,
+#'   x100 = 10,
+#'   truncation = FALSE
+#' )
 ec_normalise <- function(
   variable = NULL,
   x0 = 0,
@@ -89,12 +104,35 @@ ec_normalise <- function(
   x0h = NULL,
   fun = "linear",
   convex_exponent = 0.5,
-  concave_exponent = 2
+  concave_exponent = 2,
+  truncation = TRUE
 ) {
   if (!is_empty(x60) & !is_empty(x0h)) {
     stop(
       "Two-sided normalisation with defined x60 values are not yet supported."
     )
+  }
+
+  if (!isTRUE(truncation) && !isFALSE(truncation)) {
+    stop("`truncation` must be either TRUE or FALSE.")
+  }
+
+  if (!truncation && fun != "linear") {
+    stop(
+      "truncation = FALSE is only supported with fun = \"linear\"."
+    )
+  }
+
+  if (!is.null(variable) && !is.numeric(variable)) {
+    stop("`variable` must be a numeric vector.")
+  }
+
+  ref_values <- list(x0 = x0, x60 = x60, x100 = x100, x60h = x60h, x0h = x0h)
+  for (nm in names(ref_values)) {
+    val <- ref_values[[nm]]
+    if (!is.null(val) && !is.numeric(val)) {
+      stop("`", nm, "` must be numeric.")
+    }
   }
 
   if (
@@ -226,7 +264,9 @@ ec_normalise <- function(
     indicator <- norm_pw_lin_dec()
   }
 
-  indicator <- trunc(indicator)
+  if (truncation) {
+    indicator <- trunc(indicator)
+  }
 
   if (fun == "sigmoid") {
     indicator <- 100.68 * (1 - exp(-5 * indicator^2.5)) / 100

--- a/man/ec_normalise.Rd
+++ b/man/ec_normalise.Rd
@@ -72,8 +72,10 @@ supplied either as single values or as vectors with the same length as
 observations must either have \code{x0 < x100} or all must have \code{x0 > x100}.
 
 By default, values outside the reference range are truncated to the interval
-\verb{[0, 1]}. Set \code{truncation = FALSE} to instead extrapolate the linear mapping beyond the reference range, returning values below 0 or above 1.
-This is only available when \code{fun = "linear"}, because the non-linear transformations would otherwise produce \code{NaN} for negative extrapolated values.
+\verb{[0, 1]}. Set \code{truncation = FALSE} to instead extrapolate the linear mapping
+beyond the reference range, returning values below 0 or above 1. This is only
+available when \code{fun = "linear"}, because the non-linear transformations would
+otherwise produce \code{NaN} for negative extrapolated values.
 
 Two-sided normalisation with defined \code{x60} values is currently not supported.
 Exponential transformations are currently not supported when \code{x60} is used.

--- a/man/ec_normalise.Rd
+++ b/man/ec_normalise.Rd
@@ -13,7 +13,8 @@ ec_normalise(
   x0h = NULL,
   fun = "linear",
   convex_exponent = 0.5,
-  concave_exponent = 2
+  concave_exponent = 2,
+  truncation = TRUE
 )
 }
 \arguments{
@@ -47,6 +48,11 @@ One of \code{"linear"} (no transformation), \code{"sigmoid"}, \code{"exponential
 
 \item{concave_exponent}{Numeric. Exponent used when
 \code{fun = "exponential concave"}. Defaults to 2.}
+
+\item{truncation}{Logical. If \code{TRUE} (the default), normalised values are
+clamped to the interval \verb{[0, 1]}. If \code{FALSE}, values outside the reference
+range are linearly extrapolated and may fall below 0 or above 1. Disabling
+truncation is only supported when \code{fun = "linear"}.}
 }
 \value{
 A numeric vector with values between 0 and 1.
@@ -65,7 +71,9 @@ supplied either as single values or as vectors with the same length as
 \code{x0} and \code{x100} must be consistent for all observations; that is, all
 observations must either have \code{x0 < x100} or all must have \code{x0 > x100}.
 
-Values outside the reference range are truncated to the interval \verb{[0, 1]}.
+By default, values outside the reference range are truncated to the interval
+\verb{[0, 1]}. Set \code{truncation = FALSE} to instead extrapolate the linear mapping beyond the reference range, returning values below 0 or above 1.
+This is only available when \code{fun = "linear"}, because the non-linear transformations would otherwise produce \code{NaN} for negative extrapolated values.
 
 Two-sided normalisation with defined \code{x60} values is currently not supported.
 Exponential transformations are currently not supported when \code{x60} is used.
@@ -103,5 +111,12 @@ ec_normalise(
   variable = x,
   x0 = rep(0, length(x)),
   x100 = seq(5, 10, length.out = length(x))
+)
+
+ec_normalise(
+  variable = c(-2, 0, 5, 10, 12),
+  x0 = 0,
+  x100 = 10,
+  truncation = FALSE
 )
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(ecTools)
+
+test_check("ecTools")

--- a/tests/testthat/test-ec_normalise.R
+++ b/tests/testthat/test-ec_normalise.R
@@ -1,0 +1,148 @@
+test_that("linear increasing maps reference values correctly", {
+  x <- c(0, 5, 10)
+  expect_equal(ec_normalise(variable = x, x0 = 0, x100 = 10), c(0, 0.5, 1))
+})
+
+test_that("linear decreasing maps reference values correctly", {
+  x <- c(0, 5, 10)
+  expect_equal(ec_normalise(variable = x, x0 = 10, x100 = 0), c(1, 0.5, 0))
+})
+
+test_that("piecewise linear anchors x60 at 0.6", {
+  x <- c(0, 5, 10)
+  expect_equal(
+    ec_normalise(variable = x, x0 = 0, x60 = 5, x100 = 10),
+    c(0, 0.6, 1)
+  )
+})
+
+test_that("two-sided normalisation peaks at x100", {
+  x <- c(0, 5, 10)
+  expect_equal(
+    ec_normalise(variable = x, x0 = 0, x100 = 5, x0h = 10),
+    c(0, 1, 0)
+  )
+})
+
+test_that("vector reference values are recycled correctly", {
+  x <- c(2, 5)
+  res <- ec_normalise(
+    variable = x,
+    x0 = c(0, 0),
+    x100 = c(10, 5)
+  )
+  expect_equal(res, c(0.2, 1))
+})
+
+test_that("truncation = TRUE (default) clamps values to [0, 1]", {
+  x <- c(-5, 0, 5, 10, 15)
+  expect_equal(
+    ec_normalise(variable = x, x0 = 0, x100 = 10),
+    c(0, 0, 0.5, 1, 1)
+  )
+})
+
+test_that("truncation = FALSE extrapolates a linear increasing mapping", {
+  x <- c(-5, 0, 5, 10, 15)
+  expect_equal(
+    ec_normalise(variable = x, x0 = 0, x100 = 10, truncation = FALSE),
+    c(-0.5, 0, 0.5, 1, 1.5)
+  )
+})
+
+test_that("truncation = FALSE extrapolates a linear decreasing mapping", {
+  x <- c(-5, 0, 5, 10, 15)
+  expect_equal(
+    ec_normalise(variable = x, x0 = 10, x100 = 0, truncation = FALSE),
+    c(1.5, 1, 0.5, 0, -0.5)
+  )
+})
+
+test_that("truncation = FALSE extrapolates piecewise linear segments", {
+  x <- c(-5, 15)
+  res <- ec_normalise(
+    variable = x,
+    x0 = 0,
+    x60 = 5,
+    x100 = 10,
+    truncation = FALSE
+  )
+  # lower segment slope: 0.6 / 5 per unit; upper segment slope: 0.4 / 5 per unit
+  expect_equal(res, c(-0.6, 1.4))
+})
+
+test_that("truncation = FALSE extrapolates the two-sided mapping", {
+  x <- c(-5, 15)
+  res <- ec_normalise(
+    variable = x,
+    x0 = 0,
+    x100 = 5,
+    x0h = 10,
+    truncation = FALSE
+  )
+  expect_equal(res, c(-1, -1))
+})
+
+test_that("truncation = FALSE works with vector reference values", {
+  x <- c(-2, 10)
+  res <- ec_normalise(
+    variable = x,
+    x0 = c(0, 0),
+    x100 = c(10, 5),
+    truncation = FALSE
+  )
+  expect_equal(res, c(-0.2, 2))
+})
+
+test_that("truncation = FALSE errors with non-linear transformations", {
+  x <- c(0, 5, 10)
+  expect_error(
+    ec_normalise(variable = x, x0 = 0, x100 = 10, fun = "sigmoid", truncation = FALSE),
+    'only supported with fun = "linear"'
+  )
+  expect_error(
+    ec_normalise(
+      variable = x,
+      x0 = 0,
+      x100 = 10,
+      fun = "exponential convex",
+      truncation = FALSE
+    ),
+    'only supported with fun = "linear"'
+  )
+})
+
+test_that("non-numeric variable raises an error", {
+  expect_error(
+    ec_normalise(variable = c("a", "b", "c"), x0 = 0, x100 = 10),
+    "must be a numeric vector"
+  )
+})
+
+test_that("non-numeric reference values raise an error", {
+  x <- c(0, 5, 10)
+  expect_error(
+    ec_normalise(variable = x, x0 = "0", x100 = 10),
+    "`x0` must be numeric"
+  )
+  expect_error(
+    ec_normalise(variable = x, x0 = 0, x100 = "10"),
+    "`x100` must be numeric"
+  )
+  expect_error(
+    ec_normalise(variable = x, x0 = 0, x60 = "5", x100 = 10),
+    "`x60` must be numeric"
+  )
+})
+
+test_that("invalid truncation values raise an error", {
+  x <- c(0, 5, 10)
+  expect_error(
+    ec_normalise(variable = x, x0 = 0, x100 = 10, truncation = "yes"),
+    "must be either TRUE or FALSE"
+  )
+  expect_error(
+    ec_normalise(variable = x, x0 = 0, x100 = 10, truncation = NA),
+    "must be either TRUE or FALSE"
+  )
+})


### PR DESCRIPTION
I have added code to make the truncation step optional, for the linear functions only. If truncation is TRUE for the sigmoid function it stops and makes an error. truncation = TRUE is the default, so it does not break the function if the new argument is missing. So it should not break existing code.

I have also added tests for the ec_normalise function, because I think this should be a standart for any R package. But these can be removed if they do not fit your workflow or philosophy.